### PR TITLE
Include <unistd.h> for isatty()

### DIFF
--- a/core.c
+++ b/core.c
@@ -1,6 +1,7 @@
 #include <lua.h>
 #include <lauxlib.h>
 #include <lualib.h>
+#include <unistd.h>
 
 static int
 lua_isatty(lua_State *L)


### PR DESCRIPTION
Currently get:

```
core.c: In function 'lua_isatty':
core.c:10:5: warning: implicit declaration of function 'isatty' [-Wimplicit-function-declaration]
     lua_pushboolean(L, isatty(fileno(*fp)));
     ^
```
