### PR TITLE
Make LUA_VER and LUA_DIR override-able from environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,21 @@
 #this file builds lua-term \o/
 
-LUA_VER		?= 5.1
-LUA_DIR		?= /usr
-LUA_LIBDIR	:= $(LUA_DIR)/lib/lua/$(LUA_VER)/term
-LUA_INC		:= $(LUA_DIR)/include/lua$(LUA_VER)
-LUA_SHARE	:= $(LUA_DIR)/share/lua/$(LUA_VER)/term
-CWARNS          := -Wall -pedantic 
-CFLAGS 		:= $(CWARNS) -ansi -O3 -I$(LUA_INC) -fPIC
-LIB_OPTION	:= -shared
+LUA_VER         ?= 5.1
+LUA_DIR         ?= /usr
+LUA_LIBDIR      := $(LUA_DIR)/lib/lua/$(LUA_VER)/term
+LUA_INC         := $(LUA_DIR)/include/lua$(LUA_VER)
+LUA_SHARE       := $(LUA_DIR)/share/lua/$(LUA_VER)/term
+CWARNS          := -Wall -pedantic
+CFLAGS          := $(CWARNS) -ansi -O3 -I$(LUA_INC) -fPIC
+LIB_OPTION      := -shared
 
-SONAME   	:= core.so
-SONAMEV  	:= $(SONAME).1
-LIBRARY  	:= $(SONAMEV).0.1
-SRC      	:= core.c
-OBJ      	:= $(patsubst %.c, %.o, $(SRC))
+SONAME          := core.so
+SONAMEV         := $(SONAME).1
+LIBRARY         := $(SONAMEV).0.1
+SRC             := core.c
+OBJ             := $(patsubst %.c, %.o, $(SRC))
 
-FILES		:= term/init.lua term/cursor.lua term/colors.lua
+FILES           := term/init.lua term/cursor.lua term/colors.lua
 
 all: $(LIBRARY) $(SONAMEV) $(SONAME)
 
@@ -27,7 +27,7 @@ $(SONAME):
 
 $(LIBRARY): $(OBJ)
 	$(CC) $(CFLAGS) $(LIB_OPTION) -o $(LIBRARY) $(OBJ) -lc
-		
+
 install:
 	mkdir -p $(LUA_LIBDIR)
 	cp $(SONAME) $(LUA_LIBDIR)
@@ -36,4 +36,3 @@ install:
 
 clean:
 	$(RM) $(LIBRARY) $(SONAMEV) $(SONAME) *.o
-

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #this file builds lua-term \o/
 
-LUA_VER		:= 5.1
-LUA_DIR		:= /usr
+LUA_VER		?= 5.1
+LUA_DIR		?= /usr
 LUA_LIBDIR	:= $(LUA_DIR)/lib/lua/$(LUA_VER)/term
 LUA_INC		:= $(LUA_DIR)/include/lua$(LUA_VER)
 LUA_SHARE	:= $(LUA_DIR)/share/lua/$(LUA_VER)/term


### PR DESCRIPTION
With this patch one can do the following on OpenBSD:

```shell
$ env LUA_VER=5.3 LUA_DIR=/usr/local make
```

And thus allow other ```lua-term``` to be compiled with other Lua versions than 5.1. The Makefile thus works flawlessly with all Lua flavours that can be installed on OpenBSD. And as a bonus: The Makefile does not change in behaviour for any other system.