### PR TITLE
Update readme with OpenBSD install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,28 @@ Installation
 
 lua-term is available on Luarocks.
 
+
+## OpenBSD
+
+lua-term is available as an OpenBSD package. Use the proper Lua flavour to
+get the package for your Lua version:
+
+```
+# For Lua 5.1
+$ doas pkg_add -r lua-term
+# For Lua 5.2
+$ doas pkg_add -r lua52-term
+# For Lua 5.3
+$ doas pkg_add -r lua53-term
+```
+
+Or install from ports:
+
+```
+$ cd /usr/ports/devel/lua-term
+$ env FLAVOR=lua51 doas make install
+```
+
 Usage
 -----
 


### PR DESCRIPTION
lua-term is now officially in the OpenBSD ports tree. So on OpenBSD there's no need to use luasucks^W luarocks.