### PR TITLE
Fix term.isatty

### DIFF
--- a/core.c
+++ b/core.c
@@ -10,7 +10,7 @@
 static int
 lua_isatty(lua_State *L)
 {
-    FILE **fp = (FILE **) luaL_checkudata(L, -1, LUA_FILEHANDLE);
+    FILE **fp = (FILE **) luaL_checkudata(L, 1, LUA_FILEHANDLE);
 
     lua_pushboolean(L, isatty(fileno(*fp)));
     return 1;


### PR DESCRIPTION
Pass '1' instead of '-1' to luaL_checkudata when getting the file
argument to use the first argument, not the last. Error messages generated
by luaL_checkudata are improved.

Also, this happens to fix a crash on Lua 5.1.0 caused by a Lua bug.