### PR TITLE
refer to luasystem for Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ Clear from the current cursor position to the end of the current line.
 
 Returns `true` if `file` is a TTY; `false` otherwise.
 
-*NOTE*: This function has been deprecated in favor of luaposix's implementation.
-If you would like this functionality in the future, please use luaposix.
+*NOTE*: This function has been deprecated in favor of luasystem's implementation
+(or luaposix if you don't need Windows support).
+If you would like this functionality in the future, please use luasystem.
 
 `term.colors` Values
 ------------------


### PR DESCRIPTION
Primarily refer to luasystem, since that also supports Windows, which luaposix does not.